### PR TITLE
Fix search for __repr__s in MRO

### DIFF
--- a/easyrepr/descriptor.py
+++ b/easyrepr/descriptor.py
@@ -82,7 +82,7 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
         style_fn = None
 
         for mro_type in reversed(type(instance).__mro__):
-            repr_fn = getattr(mro_type, "__repr__", None)
+            repr_fn = mro_type.__dict__.get("__repr__", None)
 
             if not isinstance(repr_fn, EasyRepr):
                 continue

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -49,9 +49,31 @@ class GH(EF, CD, Ignored):
         return ("g", "h")
 
 
+class BaseWithEllipsis:
+    def __init__(self, *, a, b):
+        self.a = a
+        self.b = b
+
+    @easyrepr
+    def __repr__(self):
+        ...
+
+
+class EmptyDerived(BaseWithEllipsis):
+    pass
+
+
 def test_derived_repr():
     """Repr of a class hierarchy has attributes in reverse MRO"""
     obj = GH(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8)
     actual_repr = repr(obj)
 
     assert actual_repr == "GH(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8)"
+
+
+def test_derived_ellipsis():
+    """Repr of a class does not have duplicated attributes with inheritance"""
+    obj = EmptyDerived(a=1, b=2)
+    actual_repr = repr(obj)
+
+    assert actual_repr == "EmptyDerived(a=1, b=2)"


### PR DESCRIPTION
Our search for `__repr__` methods was a bit too generous. We would find a `__repr__` for `B` even in the following case:

```python
class A:
  def __repr__(self):
    ...

class B:
  pass
```

In other words, getattr will search the inheritance chain for a property, even a static property. We only want a hit for classes that define their *own* `__repr__` method, because we're walking the inheritance chain manually.

Fixes #7