### PR TITLE
Allow easyrepr to handle method names besides "__repr__"

### DIFF
--- a/easyrepr/descriptor.py
+++ b/easyrepr/descriptor.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import types
 from collections.abc import Sequence
 
@@ -79,6 +80,7 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
     """
 
     def __init__(self, wrapped, *, skip_private=True, style=None):
+        self._check_wrapped(wrapped)
         functools.update_wrapper(self, wrapped)
         self.skip_private = skip_private
         self.style = style
@@ -120,6 +122,20 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
     # EasyReprBootstrap, will replace this method with an EasyRepr instance.
     def __repr__(self):
         return (("wrapped", self.__wrapped__), ...)
+
+    def _check_wrapped(self, wrapped):
+        try:
+            signature = inspect.signature(wrapped)
+        except TypeError:
+            raise TypeError("wrapped value is not callable")
+
+        try:
+            signature.bind(None)
+        except TypeError:
+            raise TypeError(
+                "wrapped function is not callable with one positional argument "
+                "(self)"
+            )
 
     def _default_style(self):
         return call_style

--- a/easyrepr/descriptor.py
+++ b/easyrepr/descriptor.py
@@ -9,9 +9,23 @@ __all__ = ["EasyRepr"]
 
 
 class _EasyReprBootstrap(type):
+    """Use the EasyRepr to repr the EasyRepr.
+
+    We'd like to use EasyRepr for its own __repr__ implementation, but that
+    runs into a problem, because EasyRepr isn't available for use while its
+    class is still being defined. So this metaclass exists solely to wire up
+    EasyRepr.__repr__ after the fact.
+    """
+
     def __new__(cls, name, bases, dct):
         klass = super().__new__(cls, name, bases, dct)
-        klass.__repr__ = klass(klass.__repr__)
+
+        # Since we're adding this descriptor after klass was created, we're
+        # responsible for calling __set_name__ manually.
+        repr_descriptor = klass(klass.__repr__)
+        klass.__repr__ = repr_descriptor
+        repr_descriptor.__set_name__(klass, "__repr__")
+
         return klass
 
 

--- a/easyrepr/descriptor.py
+++ b/easyrepr/descriptor.py
@@ -85,6 +85,7 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
 
     def __set_name__(self, owner, name):
         self.__objclass__ = owner
+        self._name = name
 
     def __get__(self, instance, owner=None):
         if instance is None:
@@ -96,7 +97,7 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
         style_fn = None
 
         for mro_type in reversed(type(instance).__mro__):
-            repr_fn = mro_type.__dict__.get("__repr__", None)
+            repr_fn = mro_type.__dict__.get(self._name, None)
 
             if not isinstance(repr_fn, EasyRepr):
                 continue

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -24,6 +24,16 @@ class Named:
         return f"<object named {self.name}>"
 
 
+class DifferentEasyreprMethod:
+    def __init__(self, foo, bar):
+        self.foo = foo
+        self.bar = bar
+
+    @easyrepr
+    def other_method(self):
+        ...
+
+
 def test_basic_repr_free():
     """Free repr function with simple arguments returns repr"""
     obj = BasicRepr(1, 2)
@@ -64,3 +74,11 @@ def test_easyrepr_preserves_relevant_attributes():
     assert BasicRepr.__repr__.__qualname__ == "BasicRepr.__repr__"
     assert BasicRepr.__repr__.__doc__ == "Docstring for BasicRepr.__repr__"
     assert BasicRepr.__repr__.__annotations__ == {"return": "Return"}
+
+
+def test_name_other_than_repr():
+    """Easyrepr decorator on a method other than __repr__"""
+    obj = DifferentEasyreprMethod(1, 2)
+    actual_repr = obj.other_method()
+
+    assert actual_repr == "DifferentEasyreprMethod(foo=1, bar=2)"

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -1,0 +1,57 @@
+from easyrepr.descriptor import EasyRepr
+import pytest
+
+
+def defaulted_self_function(self=None):
+    ...
+
+
+def extra_defaulted_parameters_function(self, foo=None, *, bar=None):
+    ...
+
+
+def goldilocks_function(self):
+    ...
+
+
+def too_few_parameters_function():
+    ...
+
+
+def too_many_parameters_function(self, foo, bar):
+    ...
+
+
+@pytest.mark.parametrize("value", [None, 42, "hello world"])
+def test_noncallable_fails(value):
+    """Easyrepr descriptor throws TypeError for non-callable values"""
+    with pytest.raises(TypeError):
+        EasyRepr(value)
+
+
+@pytest.mark.parametrize(
+    "callable",
+    [
+        too_few_parameters_function,
+        too_many_parameters_function,
+    ],
+)
+def test_bad_signature_fails(callable):
+    """Easyrepr descriptor throws TypeError for a callable with an incompatible
+    signature.
+    """
+    with pytest.raises(TypeError):
+        EasyRepr(callable)
+
+
+@pytest.mark.parametrize(
+    "callable",
+    [
+        defaulted_self_function,
+        extra_defaulted_parameters_function,
+        goldilocks_function,
+    ],
+)
+def test_good_signature_succeeds(callable):
+    """Easyrepr descriptor succeeds for a callable with a compatible signature."""
+    EasyRepr(callable)

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -63,6 +63,27 @@ class EmptyDerived(BaseWithEllipsis):
     pass
 
 
+class BaseWithDifferentMethodName:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    @easyrepr
+    def other_method(self):
+        return ("a", "b")
+
+
+class DerivedWithDifferentMethodName(BaseWithDifferentMethodName):
+    def __init__(self, a, b, c, d):
+        super().__init__(a, b)
+        self.c = c
+        self.d = d
+
+    @easyrepr
+    def other_method(self):
+        return ("c", "d")
+
+
 def test_derived_repr():
     """Repr of a class hierarchy has attributes in reverse MRO"""
     obj = GH(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8)
@@ -77,3 +98,11 @@ def test_derived_ellipsis():
     actual_repr = repr(obj)
 
     assert actual_repr == "EmptyDerived(a=1, b=2)"
+
+
+def test_inherited_different_method_name():
+    """Class using inheritance with a method name other than __repr__"""
+    obj = DerivedWithDifferentMethodName(a=1, b=2, c=3, d=4)
+    actual_repr = obj.other_method()
+
+    assert actual_repr == "DerivedWithDifferentMethodName(a=1, b=2, c=3, d=4)"


### PR DESCRIPTION
Now when searching the inheritance chain for easyrepr methods, we will use the name of the current method, rather than the fixed name `__repr__`. This will allow easyrepr to be used with other method names, e.g., `__str__`. Also, this will allow multiple easyrepr methods in a single class.

```python
class BaseWithDifferentMethodName:
    def __init__(self, a, b):
        self.a = a
        self.b = b

    @easyrepr
    def other_method(self):
        return ("a", "b")


class DerivedWithDifferentMethodName(BaseWithDifferentMethodName):
    def __init__(self, a, b, c, d):
        super().__init__(a, b)
        self.c = c
        self.d = d

    @easyrepr
    def other_method(self):
        return ("c", "d")
```

```python
obj = DerivedWithDifferentMethodName(a=1, b=2, c=3, d=4)
actual_repr = obj.other_method()

assert actual_repr == "DerivedWithDifferentMethodName(a=1, b=2, c=3, d=4)"
```

We use the name of the set by `__set_name__`, i.e., the name in the class, rather than the `__name__` of the wrapped method. It's a small distinction that will rarely matter, but it is possible to override `__name__` to be different than what the method will be called in the class.

Fixes #12 