### PR TITLE
Include diff when running black check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           pkg-manager: poetry
       - run:
           name: Run black
-          command: poetry run black --check .
+          command: poetry run black --check --diff .
 
   lint:
     description: Check Lints


### PR DESCRIPTION
Right now it says that *something* is not formatted correctly, but not what.