### PR TITLE
Fix handling of slots

### DIFF
--- a/easyrepr/reflection.py
+++ b/easyrepr/reflection.py
@@ -1,0 +1,63 @@
+__all__ = ["is_private", "Mirror"]
+
+
+def is_private(attribute):
+    """Return whether an attribute is private."""
+    return attribute.startswith("_")
+
+
+class Mirror:
+    """Class to access attributes via reflection.
+
+    :param hide_private: do not include private (according to
+      :any:`is_private`) attributes when reflecting attributes. Default is
+      `True`.
+    """
+
+    def __init__(self, hide_private=True):
+        self.hide_private = hide_private
+
+    def reflect_classes(self, instance, bottom_up=False):
+        """Return all classes in the method resolution order (MRO) for the
+        given instance's type.
+
+        :param instance: the object whose classes should be reflected
+        :param bottom_up: if `True`, return classes from bottom (most derived)
+          to top (most base, usually :any:`object`); otherwise from top to
+          bottom. Default is `False` (top to bottom).
+        """
+        classes_bottom_up = type(instance).__mro__
+
+        if bottom_up:
+            return classes_bottom_up
+
+        return reversed(classes_bottom_up)
+
+    def reflect_attributes(self, instance):
+        """Return all visible attributes of the given instance.
+
+        :param instance: the object whose attributes should be reflected
+        """
+        attributes = []
+
+        for klass in self.reflect_classes(instance):
+            if hasattr(klass, "__slots__"):
+                attributes.extend(self._filter_private_attributes(klass.__slots__))
+
+        if hasattr(instance, "__dict__"):
+            attributes.extend(self._filter_private_attributes(instance.__dict__.keys()))
+
+        return attributes
+
+    def _filter_private_attributes(self, candidate_attributes):
+        if not self.hide_private:
+            return candidate_attributes
+
+        return (
+            attribute for attribute in candidate_attributes if not is_private(attribute)
+        )
+
+    def __repr__(self):
+        # No easy way to get EasyRepr in here. "I guide others to a treasure I
+        # cannot possess."
+        return f"Mirror(skip_private={self.hide_private})"

--- a/easyrepr/reflection.py
+++ b/easyrepr/reflection.py
@@ -12,23 +12,25 @@ class Mirror:
     :param hide_private: do not include private (according to
       :any:`is_private`) attributes when reflecting attributes. Default is
       `True`.
+    :param top_down: if `True`, reflect classes from top (most base, usually
+        :any:`object`) to bottom (most derived, i.e., the type of the
+        instance); otherwise from bottom to top. Default is `True` (top to
+        bottom).
     """
 
-    def __init__(self, hide_private=True):
+    def __init__(self, hide_private=True, top_down=True):
         self.hide_private = hide_private
+        self.top_down = top_down
 
-    def reflect_classes(self, instance, bottom_up=False):
+    def reflect_classes(self, instance):
         """Return all classes in the method resolution order (MRO) for the
         given instance's type.
 
         :param instance: the object whose classes should be reflected
-        :param bottom_up: if `True`, return classes from bottom (most derived)
-          to top (most base, usually :any:`object`); otherwise from top to
-          bottom. Default is `False` (top to bottom).
         """
         classes_bottom_up = type(instance).__mro__
 
-        if bottom_up:
+        if not self.top_down:
             return classes_bottom_up
 
         return reversed(classes_bottom_up)
@@ -41,8 +43,9 @@ class Mirror:
         attributes = []
 
         for klass in self.reflect_classes(instance):
-            if hasattr(klass, "__slots__"):
-                attributes.extend(self._filter_private_attributes(klass.__slots__))
+            slots = klass.__dict__.get("__slots__", None)
+            if slots is not None:
+                attributes.extend(self._filter_private_attributes(slots))
 
         if hasattr(instance, "__dict__"):
             attributes.extend(self._filter_private_attributes(instance.__dict__.keys()))
@@ -60,4 +63,4 @@ class Mirror:
     def __repr__(self):
         # No easy way to get EasyRepr in here. "I guide others to a treasure I
         # cannot possess."
-        return f"Mirror(skip_private={self.hide_private})"
+        return f"Mirror(skip_private={self.hide_private}, top_down={self.top_down})"

--- a/easyrepr/reflection.py
+++ b/easyrepr/reflection.py
@@ -45,7 +45,11 @@ class Mirror:
         for klass in self.reflect_classes(instance):
             slots = klass.__dict__.get("__slots__", None)
             if slots is not None:
-                attributes.extend(self._filter_private_attributes(slots))
+                attributes.extend(
+                    attribute
+                    for attribute in self._filter_private_attributes(slots)
+                    if hasattr(instance, attribute)
+                )
 
         if hasattr(instance, "__dict__"):
             attributes.extend(self._filter_private_attributes(instance.__dict__.keys()))

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -23,7 +23,7 @@ class C(B):
 
     def __init__(self):
         super().__init__()
-        # These assignments are purposefully backwards.
+        # These assignments are intentionally backwards.
         self._c2 = 6
         self.c1 = 5
 
@@ -33,6 +33,15 @@ class D(C, A):
         super().__init__()
         self.d1 = 7
         self._d2 = 8
+
+
+class E(C):
+    __slots__ = ("e1", "e2")
+
+    def __init__(self):
+        super().__init__()
+        self.e1 = 9
+        # e2 intentionally left unset.
 
 
 @pytest.mark.parametrize(
@@ -154,6 +163,12 @@ def test_mirror_reflect_classes(test_class, mirror_args, expected_classes):
             {"hide_private": False},
             ["b1", "_b2", "c1", "_c2"],
             id="C with hide_private=False",
+        ),
+        pytest.param(
+            E,
+            {},
+            ["b1", "c1", "e1"],
+            id="E with defaults",
         ),
     ],
 )

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,167 @@
+from easyrepr.reflection import is_private, Mirror
+import pytest
+
+
+class A:
+    def __init__(self):
+        super().__init__()
+        self.a1 = 1
+        self._a2 = 2
+
+
+class B:
+    __slots__ = ("b1", "_b2")
+
+    def __init__(self):
+        super().__init__()
+        self.b1 = 3
+        self._b2 = 4
+
+
+class C(B):
+    __slots__ = ("c1", "_c2")
+
+    def __init__(self):
+        super().__init__()
+        # These assignments are purposefully backwards.
+        self._c2 = 6
+        self.c1 = 5
+
+
+class D(C, A):
+    def __init__(self):
+        super().__init__()
+        self.d1 = 7
+        self._d2 = 8
+
+
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    [
+        ("abc", False),
+        ("a_b_c", False),
+        ("abc_", False),
+        ("_abc", True),
+        ("__abc", True),
+        ("foo_bar", False),
+        ("_foo_bar", True),
+        ("__foo_bar", True),
+        ("_", True),
+    ],
+)
+def test_is_private(attribute, value):
+    assert is_private(attribute) is value
+
+
+@pytest.mark.parametrize(
+    ("test_class", "mirror_args", "expected_classes"),
+    [
+        pytest.param(
+            D,
+            {},
+            [object, A, B, C, D],
+            id="D with defaults",
+        ),
+        pytest.param(
+            D,
+            {"top_down": True},
+            [object, A, B, C, D],
+            id="D with top_down=True",
+        ),
+        pytest.param(
+            D,
+            {"top_down": False},
+            [D, C, B, A, object],
+            id="D with top_down=False",
+        ),
+        pytest.param(
+            C,
+            {},
+            [object, B, C],
+            id="C with defaults",
+        ),
+        pytest.param(
+            C,
+            {"top_down": True},
+            [object, B, C],
+            id="C with top_down=True",
+        ),
+        pytest.param(
+            C,
+            {"top_down": False},
+            [C, B, object],
+            id="C with top_down=False",
+        ),
+    ],
+)
+def test_mirror_reflect_classes(test_class, mirror_args, expected_classes):
+    instance = test_class()
+    mirror = Mirror(**mirror_args)
+
+    # Result is just iterable; collect to a list for comparison.
+    actual_classes = list(mirror.reflect_classes(instance))
+
+    assert actual_classes == expected_classes
+
+
+@pytest.mark.parametrize(
+    ("test_class", "mirror_args", "expected_attributes"),
+    [
+        pytest.param(
+            D,
+            {},
+            ["b1", "c1", "a1", "d1"],
+            id="D with defaults",
+        ),
+        pytest.param(
+            D,
+            {"hide_private": True},
+            ["b1", "c1", "a1", "d1"],
+            id="D with hide_private=True",
+        ),
+        pytest.param(
+            D,
+            {"hide_private": False},
+            ["b1", "_b2", "c1", "_c2", "a1", "_a2", "d1", "_d2"],
+            id="D with hide_private=False",
+        ),
+        pytest.param(
+            D,
+            {"hide_private": True, "top_down": False},
+            ["c1", "b1", "a1", "d1"],
+            id="D with hide_private=True, top_down=False",
+        ),
+        pytest.param(
+            D,
+            {"hide_private": False, "top_down": False},
+            ["c1", "_c2", "b1", "_b2", "a1", "_a2", "d1", "_d2"],
+            id="D with hide_private=False, top_down=False",
+        ),
+        pytest.param(
+            C,
+            {},
+            ["b1", "c1"],
+            id="C with defaults",
+        ),
+        pytest.param(
+            C,
+            {"hide_private": True},
+            ["b1", "c1"],
+            id="C with hide_private=True",
+        ),
+        pytest.param(
+            C,
+            {"hide_private": False},
+            ["b1", "_b2", "c1", "_c2"],
+            id="C with hide_private=False",
+        ),
+    ],
+)
+def test_mirror_reflect_attributes(test_class, mirror_args, expected_attributes):
+    instance = test_class()
+    mirror = Mirror(**mirror_args)
+
+    # Result is just iterable; collect to a list for comparison.
+    actual_attributes = list(mirror.reflect_attributes(instance))
+
+    assert actual_attributes == expected_attributes

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -2,14 +2,14 @@ from easyrepr.reflection import is_private, Mirror
 import pytest
 
 
-class A:
+class DictBase:
     def __init__(self):
         super().__init__()
         self.a1 = 1
         self._a2 = 2
 
 
-class B:
+class SlotsBase:
     __slots__ = ("b1", "_b2")
 
     def __init__(self):
@@ -18,7 +18,7 @@ class B:
         self._b2 = 4
 
 
-class C(B):
+class SlotsDerived(SlotsBase):
     __slots__ = ("c1", "_c2")
 
     def __init__(self):
@@ -28,14 +28,14 @@ class C(B):
         self.c1 = 5
 
 
-class D(C, A):
+class DictAndSlots(SlotsDerived, DictBase):
     def __init__(self):
         super().__init__()
         self.d1 = 7
         self._d2 = 8
 
 
-class E(C):
+class SlotsOneAttrUnset(SlotsDerived):
     __slots__ = ("e1", "e2")
 
     def __init__(self):
@@ -66,40 +66,40 @@ def test_is_private(attribute, value):
     ("test_class", "mirror_args", "expected_classes"),
     [
         pytest.param(
-            D,
+            DictAndSlots,
             {},
-            [object, A, B, C, D],
-            id="D with defaults",
+            [object, DictBase, SlotsBase, SlotsDerived, DictAndSlots],
+            id="DictAndSlots with defaults",
         ),
         pytest.param(
-            D,
+            DictAndSlots,
             {"top_down": True},
-            [object, A, B, C, D],
-            id="D with top_down=True",
+            [object, DictBase, SlotsBase, SlotsDerived, DictAndSlots],
+            id="DictAndSlots with top_down=True",
         ),
         pytest.param(
-            D,
+            DictAndSlots,
             {"top_down": False},
-            [D, C, B, A, object],
-            id="D with top_down=False",
+            [DictAndSlots, SlotsDerived, SlotsBase, DictBase, object],
+            id="DictAndSlots with top_down=False",
         ),
         pytest.param(
-            C,
+            SlotsDerived,
             {},
-            [object, B, C],
-            id="C with defaults",
+            [object, SlotsBase, SlotsDerived],
+            id="SlotsDerived with defaults",
         ),
         pytest.param(
-            C,
+            SlotsDerived,
             {"top_down": True},
-            [object, B, C],
-            id="C with top_down=True",
+            [object, SlotsBase, SlotsDerived],
+            id="SlotsDerived with top_down=True",
         ),
         pytest.param(
-            C,
+            SlotsDerived,
             {"top_down": False},
-            [C, B, object],
-            id="C with top_down=False",
+            [SlotsDerived, SlotsBase, object],
+            id="SlotsDerived with top_down=False",
         ),
     ],
 )
@@ -117,58 +117,58 @@ def test_mirror_reflect_classes(test_class, mirror_args, expected_classes):
     ("test_class", "mirror_args", "expected_attributes"),
     [
         pytest.param(
-            D,
+            DictAndSlots,
             {},
             ["b1", "c1", "a1", "d1"],
-            id="D with defaults",
+            id="DictAndSlots with defaults",
         ),
         pytest.param(
-            D,
+            DictAndSlots,
             {"hide_private": True},
             ["b1", "c1", "a1", "d1"],
-            id="D with hide_private=True",
+            id="DictAndSlots with hide_private=True",
         ),
         pytest.param(
-            D,
+            DictAndSlots,
             {"hide_private": False},
             ["b1", "_b2", "c1", "_c2", "a1", "_a2", "d1", "_d2"],
-            id="D with hide_private=False",
+            id="DictAndSlots with hide_private=False",
         ),
         pytest.param(
-            D,
+            DictAndSlots,
             {"hide_private": True, "top_down": False},
             ["c1", "b1", "a1", "d1"],
-            id="D with hide_private=True, top_down=False",
+            id="DictAndSlots with hide_private=True, top_down=False",
         ),
         pytest.param(
-            D,
+            DictAndSlots,
             {"hide_private": False, "top_down": False},
             ["c1", "_c2", "b1", "_b2", "a1", "_a2", "d1", "_d2"],
-            id="D with hide_private=False, top_down=False",
+            id="DictAndSlots with hide_private=False, top_down=False",
         ),
         pytest.param(
-            C,
+            SlotsDerived,
             {},
             ["b1", "c1"],
-            id="C with defaults",
+            id="SlotsDerived with defaults",
         ),
         pytest.param(
-            C,
+            SlotsDerived,
             {"hide_private": True},
             ["b1", "c1"],
-            id="C with hide_private=True",
+            id="SlotsDerived with hide_private=True",
         ),
         pytest.param(
-            C,
+            SlotsDerived,
             {"hide_private": False},
             ["b1", "_b2", "c1", "_c2"],
-            id="C with hide_private=False",
+            id="SlotsDerived with hide_private=False",
         ),
         pytest.param(
-            E,
+            SlotsOneAttrUnset,
             {},
             ["b1", "c1", "e1"],
-            id="E with defaults",
+            id="SlotsOneAttrUnset with defaults",
         ),
     ],
 )

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,0 +1,73 @@
+from easyrepr import easyrepr
+
+
+class SlotsBase:
+    __slots__ = ("a", "b")
+
+    @easyrepr
+    def __repr__(self):
+        ...
+
+
+class SlotsDerived(SlotsBase):
+    __slots__ = ("c", "d")
+
+
+class DictDerived(SlotsDerived):
+    pass
+
+
+def test_slots_derived_full():
+    """Repr for classes using only slots should handle ellipsis."""
+    instance = SlotsDerived()
+    instance.a = 1
+    instance.b = 2
+    instance.c = 3
+    instance.d = 4
+
+    actual_repr = repr(instance)
+
+    assert actual_repr == "SlotsDerived(a=1, b=2, c=3, d=4)"
+
+
+def test_slots_derived_partial():
+    """Repr for classes using only slots should not include unset
+    attributes.
+    """
+    instance = SlotsDerived()
+    instance.a = 1
+    instance.c = 3
+
+    actual_repr = repr(instance)
+
+    assert actual_repr == "SlotsDerived(a=1, c=3)"
+
+
+def test_dict_derived_full():
+    """Repr for classes using slots and dict should handle ellipsis."""
+    instance = DictDerived()
+    instance.a = 1
+    instance.b = 2
+    instance.c = 3
+    instance.d = 4
+    instance.e = 5
+    instance.f = 6
+
+    actual_repr = repr(instance)
+
+    assert actual_repr == "DictDerived(a=1, b=2, c=3, d=4, e=5, f=6)"
+
+
+def test_dict_derived_partial():
+    """Repr for classes using slots and dict should not include unset
+    attributes.
+    """
+    instance = DictDerived()
+    instance.a = 1
+    instance.c = 3
+    instance.e = 5
+    instance.f = 6
+
+    actual_repr = repr(instance)
+
+    assert actual_repr == "DictDerived(a=1, c=3, e=5, f=6)"


### PR DESCRIPTION
This merge request adds support for classes using `__slots__` by introducing a class called `Mirror` that can correctly reflect an instance's classes and attributes (including those in slots). This also simplifies the definition of the `EasyRepr` descriptor.

Fixes #10 