### PR TITLE
Add override parameter to EasyRepr

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -458,3 +458,42 @@ frequently with inheritance.
    >>> x = DerivedEasyRepr(1, 2, 3)
    >>> repr(x)
    'DerivedEasyRepr(foo=1, bar=2, baz=3)'
+
+Overriding Inherited Methods
+----------------------------
+
+A class can override the usual search for ancestor :obj:`__repr__` methods by
+passing ``override=True`` to :func:`~easyrepr.easyrepr`.
+
+.. note::
+
+  Even with ``override=True``, :obj:`__repr__` may still refer to attributes set
+  by ancestor classes (even private ones, if desired) since attributes are not
+  actually associated to a class.
+
+.. code-block:: pycon
+   :caption: Repr overriding inherited method
+
+   >>> from easyrepr import easyrepr
+   ...
+   >>> class BaseEasyRepr:
+   ...     def __init__(self, foo, bar):
+   ...         self.foo = foo
+   ...         self.bar = bar
+   ...
+   ...     @easyrepr(style='<>')
+   ...     def __repr__(self):
+   ...         return ('foo', 'bar')
+   ...
+   >>> class DerivedEasyRepr(BaseEasyRepr):
+   ...     def __init__(self, foo, bar, baz):
+   ...         super().__init__(foo, bar)
+   ...         self.baz = baz
+   ...
+   ...     @easyrepr(override=True)
+   ...     def __repr__(self):
+   ...         return ('baz',)
+   ...
+   >>> x = DerivedEasyRepr(1, 2, 3)
+   >>> repr(x)
+   'DerivedEasyRepr(baz=3)'

--- a/easyrepr/descriptor.py
+++ b/easyrepr/descriptor.py
@@ -35,6 +35,8 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
     """Descriptor for an automatic `__repr__` method.
 
     :param wrapped: the function to wrap
+    :param override: completely replace ancestor methods rather than
+      concatenating to them. Default is `False`.
     :param skip_private: skip private attributes --- i.e., those whose names
       start with an underscore ("_") --- when finding attributes for `None` or
       `Ellipsis`. Default is `True`.
@@ -80,9 +82,11 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
       or ``(value,)``, as described above.
     """
 
-    def __init__(self, wrapped, *, skip_private=True, style=None):
+    def __init__(self, wrapped, *, override=False, skip_private=True, style=None):
         self._check_wrapped(wrapped)
         functools.update_wrapper(self, wrapped)
+
+        self.override = override
         self.style = style
 
         self._mirror = Mirror(skip_private)
@@ -100,7 +104,12 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
         attributes = []
         style_fn = None
 
-        for mro_type in self._mirror.reflect_classes(instance):
+        if self.override:
+            search_classes = (type(instance),)
+        else:
+            search_classes = self._mirror.reflect_classes(instance)
+
+        for mro_type in search_classes:
             repr_fn = mro_type.__dict__.get(self._name, None)
 
             if not isinstance(repr_fn, EasyRepr):

--- a/easyrepr/descriptor.py
+++ b/easyrepr/descriptor.py
@@ -115,7 +115,7 @@ class EasyRepr(metaclass=_EasyReprBootstrap):
             if not isinstance(repr_fn, EasyRepr):
                 continue
 
-            if repr_fn.style is not None and style_fn is None:
+            if repr_fn.style is not None:
                 style_fn = self._resolve_style(repr_fn.style)
 
             return_value = repr_fn.__wrapped__(instance)

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -2,56 +2,52 @@ from easyrepr.descriptor import EasyRepr
 import pytest
 
 
-def defaulted_self_function(self=None):
-    ...
+class TestCheckSignature:
+    """Tests related to checking the wrapped function's signature."""
 
+    def defaulted_self_function(self=None):
+        ...
 
-def extra_defaulted_parameters_function(self, foo=None, *, bar=None):
-    ...
+    def extra_defaulted_parameters_function(self, foo=None, *, bar=None):
+        ...
 
+    def goldilocks_function(self):
+        ...
 
-def goldilocks_function(self):
-    ...
+    def too_few_parameters_function():
+        ...
 
+    def too_many_parameters_function(self, foo, bar):
+        ...
 
-def too_few_parameters_function():
-    ...
+    @pytest.mark.parametrize("value", [None, 42, "hello world"])
+    def test_noncallable_fails(self, value):
+        """Easyrepr descriptor throws TypeError for non-callable values"""
+        with pytest.raises(TypeError):
+            EasyRepr(value)
 
+    @pytest.mark.parametrize(
+        "callable",
+        [
+            too_few_parameters_function,
+            too_many_parameters_function,
+        ],
+    )
+    def test_bad_signature_fails(self, callable):
+        """Easyrepr descriptor throws TypeError for a callable with an incompatible
+        signature.
+        """
+        with pytest.raises(TypeError):
+            EasyRepr(callable)
 
-def too_many_parameters_function(self, foo, bar):
-    ...
-
-
-@pytest.mark.parametrize("value", [None, 42, "hello world"])
-def test_noncallable_fails(value):
-    """Easyrepr descriptor throws TypeError for non-callable values"""
-    with pytest.raises(TypeError):
-        EasyRepr(value)
-
-
-@pytest.mark.parametrize(
-    "callable",
-    [
-        too_few_parameters_function,
-        too_many_parameters_function,
-    ],
-)
-def test_bad_signature_fails(callable):
-    """Easyrepr descriptor throws TypeError for a callable with an incompatible
-    signature.
-    """
-    with pytest.raises(TypeError):
+    @pytest.mark.parametrize(
+        "callable",
+        [
+            defaulted_self_function,
+            extra_defaulted_parameters_function,
+            goldilocks_function,
+        ],
+    )
+    def test_good_signature_succeeds(self, callable):
+        """Easyrepr descriptor succeeds for a callable with a compatible signature."""
         EasyRepr(callable)
-
-
-@pytest.mark.parametrize(
-    "callable",
-    [
-        defaulted_self_function,
-        extra_defaulted_parameters_function,
-        goldilocks_function,
-    ],
-)
-def test_good_signature_succeeds(callable):
-    """Easyrepr descriptor succeeds for a callable with a compatible signature."""
-    EasyRepr(callable)

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -51,3 +51,47 @@ class TestCheckSignature:
     def test_good_signature_succeeds(self, callable):
         """Easyrepr descriptor succeeds for a callable with a compatible signature."""
         EasyRepr(callable)
+
+
+class TestOverrideParam:
+    """Tests related to the override parameter."""
+
+    class Base:
+        def __repr__(self):
+            return [("base", "value")]
+
+        __repr__ = EasyRepr(__repr__)
+
+    class Derived(Base):
+        def __repr__(self):
+            return [("derived", "only")]
+
+        __repr__ = EasyRepr(__repr__, override=True)
+
+    def test_derived_override(self):
+        instance = self.Derived()
+        actual_repr = repr(instance)
+
+        assert actual_repr == "TestOverrideParam.Derived(derived='only')"
+
+
+class TestOverrideParamStyle:
+    """Tests related to the override parameter."""
+
+    class Base:
+        def __repr__(self):
+            return [("base", "value")]
+
+        __repr__ = EasyRepr(__repr__, style=lambda x, y, z: "base style")
+
+    class Derived(Base):
+        def __repr__(self):
+            return [("derived", "only")]
+
+        __repr__ = EasyRepr(__repr__, override=True)
+
+    def test_derived_override(self):
+        instance = self.Derived()
+        actual_repr = repr(instance)
+
+        assert actual_repr == "TestOverrideParamStyle.Derived(derived='only')"


### PR DESCRIPTION
This merge request adds an `override` parameter to the `EasyRepr` descriptor and the `easyrepr` decorator. The default is false, which preserves the current behavior. If it's true, we will not search the class hierarchy for repr methods, and will instead only use the current class's method.

```pycon
>>> from easyrepr import easyrepr
...
>>> class BaseEasyRepr:
...     def __init__(self, foo, bar):
...         self.foo = foo
...         self.bar = bar
...
...     @easyrepr(style='<>')
...     def __repr__(self):
...         return ('foo', 'bar')
...
>>> class DerivedEasyRepr(BaseEasyRepr):
...     def __init__(self, foo, bar, baz):
...         super().__init__(foo, bar)
...         self.baz = baz
...
...     @easyrepr(override=True)
...     def __repr__(self):
...         return ('baz',)
...
>>> x = DerivedEasyRepr(1, 2, 3)
>>> repr(x)
'DerivedEasyRepr(baz=3)'
```

Fixes #17 