### PR TITLE
Tweak CircleCI job definition for PyTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,7 @@ jobs:
           pkg-manager: poetry
       - run:
           name: Run pytest
-          command: |
-            mkdir test-results
-            poetry run pytest --junitxml=test-results/junit.xml
+          command: poetry run pytest --junitxml=test-results/junit.xml --verbose
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# PyTest JUnit XML Results
+test-results/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
There are a few small changes here:

1. Added the `--verbose` flag so that tests are listed individually, rather than only test suites.
2. Removed `mkdir test-results` because PyTest will create intermediate directories if necessary.
3. Added `test-results/` to `.gitignore`.

Closes #19 